### PR TITLE
Store updated deps in plugin context

### DIFF
--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -69,6 +69,8 @@ public abstract class AbstractAnalyzeMojo
 {
     // fields -----------------------------------------------------------------
 
+    protected static final String DEPENDENCY_OVERRIDES = "maven-dependency-plugin.dep-overrides";
+
     /**
      * The plexus context to look-up the right {@link ProjectDependencyAnalyzer} implementation depending on the mojo
      * configuration.
@@ -342,9 +344,22 @@ public abstract class AbstractAnalyzeMojo
 
     // private methods --------------------------------------------------------
 
+    @SuppressWarnings( "unchecked" )
     private boolean checkDependencies()
         throws MojoExecutionException
     {
+        final MavenProject project;
+        Object dependencyOverrides = getPluginContext().get( DEPENDENCY_OVERRIDES );
+        if ( dependencyOverrides == null )
+        {
+            project = this.project;
+        }
+        else
+        {
+            project = this.project.clone();
+            project.setDependencyArtifacts( ( Set<Artifact> ) dependencyOverrides );
+        }
+
         ProjectDependencyAnalysis analysis;
         try
         {

--- a/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
+++ b/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/analyze/FixMojo.java
@@ -93,6 +93,12 @@ public class FixMojo
 
       getLog().info( "Writing updated POM to " + getProject().getFile() );
       writeLines( getProject().getFile(), pomLines );
+
+      // Store the updated deps in the plugin context so the analyze mojo can access it
+      Set<Artifact> directDependencies = getProject().getDependencyArtifacts();
+      directDependencies.addAll( usedUndeclared );
+      directDependencies.removeAll( unusedDeclared );
+      getPluginContext().put( DEPENDENCY_OVERRIDES, directDependencies );
     }
   }
 


### PR DESCRIPTION
If you run the fix goal and analyze goal in the same build, right now the analyze goal won't pick up dependency changes made by the fix goal. This PR uses the plugin context to pass the updated dependencies to the analyze goal. Another option is to mutate the shared `MavenProject`, but that seemed more risky since it could affect other plugins.

@stevegutz @kmclarnon 